### PR TITLE
Release `0.2.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Release `0.2.0`
+
+*November 15th 2024*
+
+### New
+
+- [INFRA] Add automatic publishing to Pypi. 
+
 ## Release `0.1.0`
 
 *November 15th 2024*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "clinicaio"
-version = "0.1.0"
+version = "0.2.0"
 description = "A Python library for input/output management of all Clinica projects."
 license = "MIT"
 authors = ["ARAMIS Lab"]


### PR DESCRIPTION
Prepare the release of ClinicaIO `0.2.0`.

This is only to check that all the automation is working properly (publication to PyPi, documentation...).